### PR TITLE
Allow filters to be validated. And ignore invalid filters when searching

### DIFF
--- a/sandbox/pages/DataGrid.vue
+++ b/sandbox/pages/DataGrid.vue
@@ -128,9 +128,28 @@ export default defineComponent({
             ]  as BulkMethod[],
 
             tableFilters: [
-                {field: 'name', label: 'Name', default: ''},
-                {field: 'email', label: 'Email', default: ''},
-                {field: 'text', label: 'Contains words', default: ''},
+                {
+                    field: 'name',
+                    label: 'Name',
+                    default: ''
+                },
+                {
+                    field: 'email',
+                    label: 'Email',
+                    default: '',
+                    validator: (value) => {
+                        if(typeof value === 'string') {
+                            // Regex from CSE `GET /tickets` endpoint
+                            return value?.match(/^[\w.+-@]+$/)
+                        }
+                        return false;
+                    }
+                },
+                {
+                    field: 'text',
+                    label: 'Contains words',
+                    default: ''
+                },
             ] as FilterDefinition[],
             staticData: [
                 {key: 1, name: 'John Doe', email: 'j.doe@example.com', text: 'Maecenas pretium posuere leo, interdum placerat ante placerat quis. Vivamus imperdiet ultricies sapien id posuere. Curabitur pharetra, risus nec interdum commodo, arcu ex dapibus nisl, eu pellentesque dolor ipsum quis dui. Praesent nec molestie ligula. Praesent feugiat dolor lobortis ante porttitor consequat. Nullam in varius tellus. Ut faucibus magna elit, a tincidunt lorem fermentum sed.'},

--- a/src/components/etDataGrid/interfaces/DataGridMethods.ts
+++ b/src/components/etDataGrid/interfaces/DataGridMethods.ts
@@ -22,6 +22,7 @@ export interface FilterDefinition {
     field: string;
     label?: string;
     default?: FilterValue;
+    validator?: (value: FilterValue) => boolean;
 }
 
 export interface CheckedProvide<T extends RowObject = RowObject> {


### PR DESCRIPTION
Optional filter definition field that accepts a method that will validate the value and returns a boolean.

If the filter is deemed invalid, the input field will be marked red, and the value will not be applied to the search input when pressing search.