### PR TITLE
Added filter saving to table

### DIFF
--- a/sandbox/pages/DataGrid.vue
+++ b/sandbox/pages/DataGrid.vue
@@ -1,25 +1,36 @@
 <template>
-    <div style="border: 1px solid blue;">
-        testing box
-        <div id="inputTeleportBox"></div>
-    </div>
+    <EtContent>
+        <div style="margin: 15px;">
+            Saved filters:
+            <EtButtonGroup v-if="filterSaving?.savedFilters">
+                <EtButtonDefault
+                    :size="UI_SIZING.S"
+                    v-for="savedFilter in filterSaving.savedFilters"
+                    @click="filterSaving.setFilters(savedFilter.name)"
+                >
+                    {{savedFilter.name}}
+                </EtButtonDefault>
+            </EtButtonGroup>
+        </div>
 
-    <EtDataGrid
-        filterTeleportTarget="#inputTeleportBox"
-        name="datagridtest"
-        ref="table"
-        :rowInfo="rowInfo"
-        :filters="tableFilters"
-        :columns="columns"
-        :bulk-methods="bulkMethods"
-        :data-getter="dataGetter"
-        @checked="onRowsChecked"
-    ></EtDataGrid>
+        <EtDataGrid
+            name="datagridtest"
+            ref="table"
+            :rowInfo="rowInfo"
+            :filters="tableFilters"
+            :columns="columns"
+            :bulk-methods="bulkMethods"
+            :data-getter="dataGetter"
+            @checked="onRowsChecked"
+            @mounted="onDataGridMount"
+        ></EtDataGrid>
+    </EtContent>
 </template>
 
 <script lang="ts">
+import EtContent from "src/layouts/Content.vue";
 import EtDataGrid from "src/components/etDataGrid/EtDataGrid.vue";
-import {defineComponent, markRaw} from "vue";
+import {defineComponent, markRaw, type UnwrapNestedRefs} from "vue";
 import type {DataGridColumn} from "../../src/components/etDataGrid/interfaces/DataGridColumn";
 
 import EtDataGridCustomComponentCellTest from "../parts/DataGridCustomComponentCellTest.vue";
@@ -29,9 +40,16 @@ import type {
     FilterDateValue,
     SortingObject
 } from "../../src/components/etDataGrid/interfaces/DataGridMethods";
+import {
+    type FilterDefinition,
+    FilterInputType,
+    type FilterSavingProvide
+} from "../../src/components/etDataGrid/interfaces/DataGridMethods";
 import EtIconPaperclip from "../../src/components/etIcon/EtIconPaperclip.vue";
-import {type FilterDefinition, FilterInputType} from "../../src/components/etDataGrid/interfaces/DataGridMethods";
 import {OptionModel} from "../../src/models/Option";
+import EtButtonGroup from "../../src/components/etButton/EtButtonGroup.vue";
+import EtButtonDefault from "../../src/components/etButton/EtButtonDefault.vue";
+import {UI_SIZING} from "../../src/helpers/enums";
 
 type ExampleRow = {
     key: number,
@@ -41,7 +59,15 @@ type ExampleRow = {
 }
 
 export default defineComponent({
+    computed: {
+        UI_SIZING() {
+            return UI_SIZING
+        }
+    },
     components: {
+        EtContent,
+        EtButtonDefault,
+        EtButtonGroup,
         EtDataGrid
     },
     data() {
@@ -255,10 +281,24 @@ export default defineComponent({
                 {key: 68, name: 'Jerry Doe', email: 'j.doe@example.com', text: ''},
                 {key: 69, name: 'Joe Doe', email: 'j.doe@example.com', text: ''},
                 {key: 70, name: 'Jesse Doe', email: 'j.doe@example.com', text: ''},
-            ] as ExampleRow[]
+            ] as ExampleRow[],
+
+            filterSaving: null as UnwrapNestedRefs<FilterSavingProvide> | null
+        }
+    },
+    watch: {
+        "filterSaving.savedFilters": {
+            immediate: true,
+            deep: true,
+            handler() {
+                console.log('filterSaving', this.filterSaving?.savedFilters);
+            }
         }
     },
     methods: {
+        onDataGridMount(ctx: {filterSaving: UnwrapNestedRefs<FilterSavingProvide>}) {
+            this.filterSaving = ctx.filterSaving;
+        },
         handleRowClick(row: ExampleRow) {
             console.log('ROW HAS BEEN CLICKED ON!');
             console.log(row);

--- a/src/components/etDataGrid/composables/useFilterSaving.ts
+++ b/src/components/etDataGrid/composables/useFilterSaving.ts
@@ -1,0 +1,94 @@
+import { reactive, ref } from "vue";
+import type {
+    FilterObject,
+    FilterSavingProvide,
+    FiltersProvide,
+    SavedFiltersSet
+} from "../interfaces/DataGridMethods";
+
+const SAVE_FILTERS_STORAGE_KEY = "ET-SDK-DATA-GRID--SAVED-FILTERS";
+
+export function useFilterSaving(tableName: string, filters: FiltersProvide) {
+    const savedFilters = ref<SavedFiltersSet[]>([]);
+    const key = `${SAVE_FILTERS_STORAGE_KEY}+${tableName}`;
+
+    function setFilters(name: string) {
+        const savedFiltersSet = savedFilters.value.find((f) => f.name === name);
+
+        if (savedFiltersSet) {
+            filters.setFilters(savedFiltersSet.filters);
+        }
+    }
+
+    function saveFilters(name: string, filtersObj: FilterObject) {
+        const amountOfFilters = Object.keys(filtersObj).length;
+        if (amountOfFilters <= 0) {
+            return;
+        }
+
+        const currentIndex = savedFilters.value.findIndex(
+            (f) => f.name === name
+        );
+
+        if (currentIndex >= 0) {
+            savedFilters.value[currentIndex].filters = filtersObj;
+        } else {
+            savedFilters.value.push({ name, filters: filtersObj });
+        }
+
+        saveAllFilters();
+    }
+
+    function saveAllFilters() {
+        window.localStorage.removeItem(key);
+
+        if (!savedFilters.value) {
+            return;
+        }
+
+        const savedFiltersDataString = JSON.stringify(savedFilters.value);
+
+        if (!savedFiltersDataString) {
+            return;
+        }
+
+        const savedFiltersDataBase64 = btoa(savedFiltersDataString);
+
+        if (!savedFiltersDataBase64) {
+            return;
+        }
+
+        window.localStorage.setItem(key, savedFiltersDataBase64);
+    }
+
+    function loadAllFilters() {
+        const savedFiltersDataBase64 = window.localStorage.getItem(key);
+        if (!savedFiltersDataBase64) {
+            savedFilters.value = [];
+            return;
+        }
+
+        const savedFiltersDataString = atob(savedFiltersDataBase64);
+        if (!savedFiltersDataString) {
+            savedFilters.value = [];
+            return;
+        }
+
+        savedFilters.value = JSON.parse(
+            savedFiltersDataString
+        ) as SavedFiltersSet[];
+    }
+
+    function getAllFilters() {
+        return savedFilters;
+    }
+
+    loadAllFilters();
+
+    return reactive<FilterSavingProvide>({
+        savedFilters,
+        setFilters,
+        saveFilters,
+        getAllFilters
+    });
+}

--- a/src/components/etDataGrid/interfaces/DataGridMethods.ts
+++ b/src/components/etDataGrid/interfaces/DataGridMethods.ts
@@ -1,6 +1,7 @@
 import type { DataGridColumn } from "./DataGridColumn";
 import type { Raw } from "@vue/reactivity";
 import { type IOption, OptionModel } from "../../../models/Option";
+import type { Ref } from "vue";
 
 export type RowObject<T extends object = { [key: string]: any }> = T;
 
@@ -161,4 +162,16 @@ export interface RowVersionProvider<T extends RowObject = RowObject> {
     versions: Record<string, number>;
     reset: (rows: T[]) => void;
     increment: (row: T) => void;
+}
+
+export interface SavedFiltersSet {
+    name: string;
+    filters: FilterObject;
+}
+
+export interface FilterSavingProvide {
+    savedFilters: Ref<SavedFiltersSet[]>;
+    setFilters: (name: string) => void;
+    saveFilters: (name: string, filters: FilterObject) => void;
+    getAllFilters: () => Ref<SavedFiltersSet[]>;
 }

--- a/src/components/etDataGrid/internals/filters/EtDataGridFiltersInput.vue
+++ b/src/components/etDataGrid/internals/filters/EtDataGridFiltersInput.vue
@@ -46,6 +46,13 @@
                     />
                 </div>
                 <div class="et-sdk-data-grid__filters-functionality">
+                    <EtButtonDefault
+                        v-if="filterSaving"
+                        class="et-sdk-data-grid__filters-search-button"
+                        @click="() => saveFilters()"
+                    >
+                        Save search filter
+                    </EtButtonDefault>
                     <EtButtonPrimary
                         class="et-sdk-data-grid__filters-search-button"
                         @click="() => applyFilters()"
@@ -76,19 +83,24 @@ import type {
     FilterDefinition,
     FilterDisplay,
     FilterObject,
+    FilterSavingProvide,
     FiltersProvide,
     FiltersStagingProvide
 } from "../../interfaces/DataGridMethods";
 import type { Instance } from "@popperjs/core/lib/types";
 import { createPopper } from "@popperjs/core";
-import type { IEtOverlayProvide } from "../../../etProvider/EtOverlayProviderInterfaces";
-import { EtOverlayEvent } from "../../../etProvider/EtOverlayProviderInterfaces";
+import {
+    EtOverlayEvent,
+    type IEtOverlayProvide
+} from "../../../etProvider/EtOverlayProviderInterfaces";
 
 import EtButtonPrimary from "../../../etButton/EtButtonPrimary.vue";
+import EtButtonDefault from "../../../etButton/EtButtonDefault.vue";
 import EtDataGridFilter from "./EtDataGridFilter.vue";
 import EtDataGridFiltersInputValue from "./EtDataGridFiltersInputValue.vue";
 
 const filters = inject<FiltersProvide>("filters");
+const filterSaving = inject<FilterSavingProvide>("filterSaving");
 const sdkOverlay = inject<IEtOverlayProvide>("SDKOverlayProvide");
 
 const filterDefinitions = computed(() => filters?.getFiltersDefinitions());
@@ -123,6 +135,19 @@ const content = ref<HTMLElement | null>(null);
 const isVisible = ref(false);
 provide<Ref<boolean>>("dropDownVisible", isVisible);
 let popperInstance: Instance;
+
+function saveFilters() {
+    if (!filterSaving || !filterValueStaging) {
+        return;
+    }
+
+    // Todo, to be replaced with a nice modal
+    const name = prompt("Name");
+
+    if (name) {
+        filterSaving.saveFilters(name, filterValueStaging.filtersValues);
+    }
+}
 
 async function toggleInput() {
     if (isVisible.value) {
@@ -283,7 +308,21 @@ onBeforeUnmount(() => {
     background-color: var(--et-sdk-dark-50);
 
     display: flex;
-    flex-direction: row-reverse;
+    flex-direction: row;
+    justify-content: flex-end;
+}
+
+.et-sdk-data-grid__filters-functionality > * {
+    margin-left: 8px;
+    margin-right: 8px;
+}
+
+.et-sdk-data-grid__filters-functionality > *:first-child {
+    margin-left: 0;
+}
+
+.et-sdk-data-grid__filters-functionality > *:last-child {
+    margin-right: 0;
 }
 
 .et-sdk-data-grid__filter-content__filter-placeholder {


### PR DESCRIPTION
Quick note: How it looks in the sandbox environment is probably not how it will be used in a real application. But just a quick demonstration.

- Save filters via filter modal. This currently still uses `prompt` in the future this will be replaced by a nice modal
- expose savedFilters via an on-mount emit so it can be used (reactively) by parent components to render the saved filters wherever they want.